### PR TITLE
chore(deps): ignore eslint/typescript major bumps blocked by peer deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,11 @@ updates:
       interval: 'monthly'
     ignore:
       - dependency-name: 'eslint'
-        versions: ['>=9.0.0']
+        versions: ['>=10.0.0']
+      - dependency-name: '@eslint/js'
+        versions: ['>=10.0.0']
+      - dependency-name: 'typescript'
+        versions: ['>=6.1.0']
     groups:
       react:
         patterns:


### PR DESCRIPTION
## Summary

CI on #798 and #783 fails with npm ERESOLVE errors. Root cause: both PRs bump a package past a range still constrained by a peer dependency upstream hasn't updated for yet.

- **#798**: bumps `typescript` to `^7.0.2`, but `typescript-eslint` (even latest 8.67.0) requires `typescript: ">=4.8.4 <6.1.0"`.
- **#783**: bumps `@eslint/js` to `10.0.1`, which needs `eslint@^10`, but `eslint` itself is excluded from that bump by the existing dependabot ignore rule. Even if bumped, `eslint-plugin-react` (latest 7.37.5) still caps `eslint` at `^9.7` — no release supports eslint 10 yet.

Neither is fixable at the PR level; the blocking constraint lives in packages we don't control. This PR extends the dependabot ignore rules so these premature bumps stop being proposed until upstream compatibility lands:

- `eslint` / `@eslint/js`: ignore `>=10.0.0`
- `typescript`: ignore `>=6.1.0`

## Goal

Stop CI from failing on doomed dependency bumps; #798 and #783 should be closed as unfixable until upstream (`typescript-eslint`, `eslint-plugin-react`) release compatible versions.