### PR TITLE
✨ Serve attachments through /api and proxy it in the image

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,8 +79,11 @@ for the whole stack are documented at <https://systemli.github.io/ticker/>.
 ## API Integration
 
 - Backend URL: `TICKER_API_URL` env var (Vite prefix: `TICKER_`). Must include the `/v1`
-  suffix; falls back to a relative `/api` that a proxy is expected to forward.
-- Endpoints: `/init` (metadata), `/timeline` (messages), `/ws` (WebSocket)
+  suffix; falls back to a relative `/api` that a proxy is expected to forward — the dev server and
+  the Docker image both provide one, so leaving it unset is the normal case.
+- Endpoints: `/init` (metadata), `/timeline` (messages), `/ws` (WebSocket), `/media/<file>`
+  (attachments). Attachment URLs come back relative as `/api/media/<file>`; resolve them with
+  `mediaUrl()` from `src/lib/api.ts` so they also work with an absolute `TICKER_API_URL`.
 - Response format: `{ data: { ... } }` wrapper
 - The API resolves which ticker to serve from the request's `Origin`, so the address the app is
   served from must be registered on the ticker in the admin interface.

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,12 @@ RUN npm run build
 FROM nginx:stable-alpine3.23
 
 COPY --from=builder /app/dist /usr/share/nginx/html
-COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+# Rendered by the base image's envsubst at container start, so TICKER_API_URL is
+# a runtime setting rather than a mount. The default only keeps nginx starting --
+# it resolves an unset variable and an unresolvable upstream is a fatal error, so
+# without it the container would exit instead of serving the app. Override it with
+# the address of your API.
+ENV TICKER_API_URL=http://127.0.0.1:8080/v1
+COPY docker/nginx.conf.template /etc/nginx/templates/default.conf.template
 
 EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -43,18 +43,18 @@ npm install
 npm run dev        # http://localhost:4000
 ```
 
-Point it at your API with a `.env` file. The URL must include the `/v1` suffix:
+The dev server proxies `/api` to `http://localhost:8080/v1`, so run the API alongside it and nothing
+needs configuring.
 
-```shell
-TICKER_API_URL=http://localhost:8080/v1
-```
+> **Delete a leftover `.env`.** `TICKER_API_URL` overrides the proxy with an absolute address.
+> Requests still work, but attachment images do not: their URLs are relative and would resolve
+> against the dev server instead of the API. The file is gitignored, so an old one may still be in
+> your checkout.
 
-Without this the application falls back to a relative `/api`, which only works when something is
-proxying that path — as the Docker image expects. Restart the dev server after changing `.env`.
-
-> **The ticker must know this address.** The API works out which ticker to serve from the browser's
-> `Origin` header, so `http://localhost:4000` has to be registered under the ticker's websites in the
-> admin interface. Otherwise the page only ever shows "The ticker is currently inactive".
+> **The ticker must know this address.** The API works out which ticker to serve from the request's
+> `Origin` header, which the proxy sets to `http://localhost:4000`. That address has to be registered
+> under the ticker's websites in the admin interface. Otherwise the page only ever shows "The ticker
+> is currently inactive".
 
 ### Commands
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     build: .
     ports:
       - '8080:80'
-    volumes:
-      - ./docker/nginx.conf.template:/etc/nginx/templates/default.conf.template:ro
-    env_file:
-      - .env
+    environment:
+      # Must include the /v1 suffix.
+      TICKER_API_URL: ${TICKER_API_URL:-http://host.docker.internal:8080/v1}

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,9 +1,0 @@
-server {
-    listen 80;
-    root /usr/share/nginx/html;
-    index index.html;
-
-    location / {
-        try_files $uri $uri/ /index.html;
-    }
-}

--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -3,7 +3,13 @@
 #
 # TICKER_API_URL must include the /v1 suffix, for example
 # http://ticker:8080/v1 -- the application requests paths below /api/, which
-# this proxy maps onto the API's /v1 routes.
+# this proxy maps onto the API's /v1 routes. Attachments are among them, at
+# /api/media/<file>.
+#
+# It has to be set: nginx refuses to start with an empty or unresolvable
+# proxy_pass. Note the same name is a build-time variable for the application
+# bundle; the published image is built without it, so the value here configures
+# this proxy only.
 
 map $http_upgrade $connection_upgrade {
     default upgrade;
@@ -17,6 +23,16 @@ server {
 
     # The API accepts uploads up to 10 MB; nginx would otherwise cap them at 1 MB.
     client_max_body_size 10m;
+
+    # Attachments. Buffered and cacheable, unlike the rest of /api/, and they
+    # need no Origin because the API resolves them by UUID.
+    location /api/media/ {
+        proxy_pass ${TICKER_API_URL}/media/;
+        proxy_ssl_server_name on;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
 
     location /api/ {
         proxy_pass ${TICKER_API_URL}/;

--- a/src/components/Attachments.tsx
+++ b/src/components/Attachments.tsx
@@ -1,4 +1,5 @@
 import { FC, useState } from 'react'
+import { mediaUrl } from '../lib/api'
 import { Attachment } from '../lib/types'
 import Lightbox from './Lightbox'
 
@@ -19,14 +20,14 @@ const Attachments: FC<Props> = ({ attachments }) => {
     return null
   }
 
-  const images = attachments?.map(attachment => attachment.url) ?? []
+  const images = attachments?.map(attachment => mediaUrl(attachment.url)) ?? []
 
   return (
     <div>
       <div className={`mt-2 grid max-h-full grid-flow-col gap-1 md:max-h-3/6 md:gap-2`}>
         {attachments?.map((attachment, key) => (
           <button key={attachment.url} onClick={() => handleClick(key)}>
-            <img src={attachment.url} className="rounded" alt="" />
+            <img src={mediaUrl(attachment.url)} className="rounded" alt="" />
           </button>
         ))}
       </div>

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,4 +1,4 @@
-import { getInit, getTimeline } from './api'
+import { getInit, getTimeline, mediaUrl } from './api'
 
 describe('api', function () {
   beforeEach(() => {
@@ -51,5 +51,11 @@ describe('api', function () {
     expect(response).not.toBeNull()
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith('/api/timeline?before=1')
+  })
+
+  test('mediaUrl', function () {
+    // ApiUrl is the relative default in tests, so the URL passes through.
+    expect(mediaUrl('/api/media/uuid.jpg')).toEqual('/api/media/uuid.jpg')
+    expect(mediaUrl('https://cdn.example.org/media/uuid.jpg')).toEqual('https://cdn.example.org/media/uuid.jpg')
   })
 })

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2,6 +2,13 @@ import { Message, Settings, Ticker } from './types'
 
 export const ApiUrl = import.meta.env.TICKER_API_URL || '/api'
 
+// The API returns attachment URLs relative to the site serving them, as
+// /api/media/<file>. That resolves by itself with the default relative ApiUrl,
+// but not when TICKER_API_URL points somewhere else.
+export function mediaUrl(url: string): string {
+  return url.startsWith('/api/') ? `${ApiUrl}${url.slice('/api'.length)}` : url
+}
+
 type InitResponseData = {
   settings: Settings
   ticker: Ticker | null

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,17 @@ export default defineConfig({
   envPrefix: 'TICKER_',
   server: {
     port: 4000,
+    // Mirrors production: the app requests /api and the proxy maps it onto the
+    // API's /v1 routes. Origin has to be set explicitly, because a same-origin
+    // GET does not send one and the API resolves the ticker from it.
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        rewrite: path => path.replace(/^\/api/, '/v1'),
+        ws: true,
+        headers: { Origin: 'http://localhost:4000' },
+      },
+    },
   },
   plugins: [
     react(),


### PR DESCRIPTION
## Goal

Companion to systemli/ticker#472, which stops the API from needing a public hostname of its own. Attachment URLs it returns are now relative, `/api/media/<file>`, so they are served by whichever site the page came from.

## What changes

**Resolve attachment URLs against the API base.** With the default relative `ApiUrl` the URL passes through untouched. With an absolute `TICKER_API_URL`, fetches would go to the API while images resolved against the app's own origin, which serves no `/api`. `mediaUrl()` closes that gap in one line and is a no-op in every shipped configuration.

**Ship the nginx proxy template in the image.** The image baked `docker/nginx.conf`, which serves the SPA and nothing else; the `/api` proxy sat in a template that only took effect if someone mounted it at runtime. Without a proxy in front the published image had no API — and, now that attachment URLs are relative, no images either. The template is copied to `/etc/nginx/templates/` instead and rendered by the base image at start, making `TICKER_API_URL` a runtime setting. It carries a default, because nginx treats both an unset variable and an unresolvable upstream as fatal and the container would otherwise exit instead of serving the app. Attachments get their own `location`, buffered and cacheable, unlike the websocket the shared `/api/` block is tuned for.

**Proxy `/api` from the dev server.** Development pointed the app at an absolute API URL, which no longer works for attachments. The Vite server now proxies `/api` the way production does and sets `Origin` explicitly, because a same-origin GET does not send one and the API resolves the ticker from it.

## Note for developers

`.env` is gitignored, so an existing checkout may still contain an absolute `TICKER_API_URL`. It overrides the proxy and breaks attachment images while everything else keeps working — delete it. The README says so as well.